### PR TITLE
Correct ETag header name

### DIFF
--- a/lib/webrick/httpresponse.rb
+++ b/lib/webrick/httpresponse.rb
@@ -229,7 +229,7 @@ module WEBrick
       if @http_version.major > 0
         data = status_line()
         @header.each{|key, value|
-          tmp = key.gsub(/\bwww|^te$|\b\w/){ $&.upcase }
+          tmp = (key == 'etag' ? 'ETag' : key.gsub(/\bwww|^te$|\b\w/){ $&.upcase })
           data << "#{tmp}: #{value}" << CRLF
         }
         @cookies.each{|cookie|


### PR DESCRIPTION
The spelling/case of the ETag header is a bit different from most (all?) other HTTP header fields, it's called 'ETag' and not 'Etag'. See [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) - Section 14.19

This pull request add a "special" handling of this header instead of the normal upcase call.
